### PR TITLE
Use dependencies with support for Node 10.16.3, bump version to 2.0.0

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -3,7 +3,7 @@ var debug = require('debug')('hci');
 var events = require('events');
 var util = require('util');
 
-var BluetoothHciSocket = require('bluetooth-hci-socket');
+var BluetoothHciSocket = require('@abandonware/bluetooth-hci-socket');
 
 var HCI_COMMAND_PKT = 0x01;
 var HCI_ACLDATA_PKT = 0x02;

--- a/lib/hci-socket/mgmt.js
+++ b/lib/hci-socket/mgmt.js
@@ -3,7 +3,7 @@ var debug = require('debug')('mgmt');
 var events = require('events');
 var util = require('util');
 
-var BluetoothHciSocket = require('bluetooth-hci-socket');
+var BluetoothHciSocket = require('@abandonware/bluetooth-hci-socket');
 
 var LTK_INFO_SIZE = 36;
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/k4connect/bleno"
+    "url": "https://github.com/sandeepmistry/bleno"
   },
   "keywords": [
     "BLE",
@@ -28,7 +28,10 @@
     "Bluetooth Smart",
     "peripheral"
   ],
-  "author": "K4Connect, Inc.",
+  "author": "Sandeep Mistry <sandeep.mistry@gmail.com>",
+  "maintainers": [
+    "Jacob Rosenthal"
+  ],
   "license": "MIT",
   "readmeFilename": "README.md",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "bleno",
-  "version": "0.5.0",
+  "name": "@k4connect/bleno",
+  "version": "1.0.0",
   "description": "A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals",
   "main": "index.js",
   "engines": {
-    "node": ">=0.8"
+    "node": ">=10.16.3"
   },
   "os": [
     "darwin",
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/sandeepmistry/bleno"
+    "url": "https://github.com/k4connect/bleno"
   },
   "keywords": [
     "BLE",
@@ -28,24 +28,21 @@
     "Bluetooth Smart",
     "peripheral"
   ],
-  "author": "Sandeep Mistry",
-  "maintainers": [
-    "Jacob Rosenthal"
-  ],
+  "author": "K4Connect, Inc.",
   "license": "MIT",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "jshint": "~2.9.4",
-    "should": "~2.0.2",
-    "mocha": "~1.14.0",
-    "node-blink1": "~0.2.2"
+    "jshint": "2.10.2",
+    "should": "13.2.3",
+    "mocha": "6.2.2",
+    "node-blink1": "0.2.4"
   },
   "dependencies": {
-    "debug": "^2.2.0"
+    "@abandonware/bluetooth-hci-socket": "0.5.3-3",
+    "debug": "4.1.1"
   },
   "optionalDependencies": {
-    "bluetooth-hci-socket": "^0.5.1",
-    "bplist-parser": "0.0.6",
-    "xpc-connection": "~0.1.4"
+    "bplist-parser": "0.1.1",
+    "xpc-connection": "0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k4connect/bleno",
-  "version": "1.0.0",
+  "version": "0.5.0-k4-1",
   "description": "A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Most important change here is the `bluetooth-hci-socket` library, which does not compile properly on Node.js 10 with the version in either K4Connect's fork nor in `noble`'s main upstream.

See this Github discussion for more context: https://github.com/noble/node-bluetooth-hci-socket/pull/91#issuecomment-448660592